### PR TITLE
Require libOmxVidEnc.so to support video recording

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -159,6 +159,7 @@ COMMON_LIBS="
 	libOmxAacDec.so
 	libOmxH264Dec.so
 	libOmxMp3Dec.so
+	libOmxVidEnc.so
 	libOmxVp8Dec.so
 	liboncrpc.so
 	libpbmlib.so


### PR DESCRIPTION
Repairing video recording also requires an updated media_profiles.xml, which is coming soon.

What is required to make sure these files aren't missed in future target branches?
