### PR TITLE
Bug 814797 - Remove ATFWD-daemon since it doesn't seem to be working:

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -195,7 +195,6 @@ COMMON_LIBS="
 copy_files "$COMMON_LIBS" "system/lib" ""
 
 COMMON_BINS="
-	ATFWD-daemon
 	akmd8962_new
 	bridgemgrd
 	ext4check.sh


### PR DESCRIPTION
I noticed (as mentioned in bug 814797) that there is a new ATFWD-daemon being launched every 5 seconds. This removes it, since I don't think we're using it anyways.
